### PR TITLE
BUGFIX: Second share dialog froze up safari

### DIFF
--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -152,11 +152,8 @@
 }
 - (void) viewDidAppear:(BOOL)animated {
     [self.view endEditing:YES];
-}
-
-- (void) viewDidLoad {
     [self setup];
-    [self debug:@"[viewDidLoad]"];
+    [self debug:@"[viewDidAppear]"];
 
     BOOL isLoggedIn = [self.userDefaults boolForKey:@"loggedIn"];
 

--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -157,7 +157,8 @@
 
     BOOL isLoggedIn = [self.userDefaults boolForKey:@"loggedIn"];
 
-    if (!isLoggedIn) {
+    //if (!isLoggedIn)
+    {
 
         NSString *alertTitle = NSLocalizedString(@"Sharing error", @"Sharing error alert title");
         NSString *alertMessage = NSLocalizedString(@"You have to be logged in in order to share items.", @"Sharing error alert message");


### PR DESCRIPTION
This fix moves the share handling from viewDidLoad to viewDidAppear, which keeps the UI from getting locked up.