### PR TITLE
Fix URL Opening from Share Extension on iOS 18+

### DIFF
--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -141,6 +141,26 @@
         }
     }
 }
+- (BOOL)openURLModern:(NSURL *)url {
+    UIResponder *responder = self;
+    while (responder) {
+        if ([responder isKindOfClass:[UIApplication class]]) {
+            UIApplication *application = (UIApplication *)responder;
+            if (@available(iOS 18.0, *)) {
+                [application openURL:url options:@{} completionHandler:nil];
+                return YES;
+            } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                BOOL result = [application performSelector:@selector(openURL:) withObject:url] != nil;
+#pragma clang diagnostic pop
+                return result;
+            }
+        }
+        responder = [responder nextResponder];
+    }
+    return NO;
+}
 - (void) viewDidAppear:(BOOL)animated {
     [self.view endEditing:YES];
 
@@ -263,7 +283,7 @@
         // Emit a URL that opens the cordova app
         NSString *url = [NSString stringWithFormat:@"%@://shared", SHAREEXT_URL_SCHEME];
 
-        [self openURL:[NSURL URLWithString:url]];
+        [self openURLModern:[NSURL URLWithString:url]];
 
         // Shut down the extension
         [self.extensionContext completeRequestReturningItems:@[] completionHandler:nil];

--- a/src/ios/ShareExtension/ShareViewController.m
+++ b/src/ios/ShareExtension/ShareViewController.m
@@ -123,25 +123,7 @@
     return YES;
 }
 
-- (void) openURL:(nonnull NSURL *)url {
-    SEL selector = NSSelectorFromString(@"openURL:");
-    UIResponder* responder = self;
-    while ((responder = [responder nextResponder]) != nil) {
-        NSLog(@"responder = %@", responder);
-        if([responder respondsToSelector:selector] == true) {
-            NSMethodSignature *methodSignature = [responder methodSignatureForSelector:selector];
-            NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
-
-            [invocation setTarget: responder];
-            [invocation setSelector: selector];
-            [invocation setArgument: &url atIndex: 2];
-
-            [invocation invoke];
-            break;
-        }
-    }
-}
-- (BOOL)openURLModern:(NSURL *)url {
+- (BOOL)openURL:(NSURL *)url {
     UIResponder *responder = self;
     while (responder) {
         if ([responder isKindOfClass:[UIApplication class]]) {
@@ -283,7 +265,7 @@
         // Emit a URL that opens the cordova app
         NSString *url = [NSString stringWithFormat:@"%@://shared", SHAREEXT_URL_SCHEME];
 
-        [self openURLModern:[NSURL URLWithString:url]];
+        [self openURL:[NSURL URLWithString:url]];
 
         // Shut down the extension
         [self.extensionContext completeRequestReturningItems:@[] completionHandler:nil];


### PR DESCRIPTION
Updated the implementation to support opening URLs from the share extension on iOS 18 and above.
Replaced the deprecated openURL approach with a method adapted from this [Stack Overflow solution](https://stackoverflow.com/questions/27506413/share-extension-to-open-containing-app/78975759#78975759), translated to Objective-C.

